### PR TITLE
add ue44 class with updated br

### DIFF
--- a/spectrainterface/sources.py
+++ b/spectrainterface/sources.py
@@ -471,6 +471,25 @@ class Apple2(Undulator):
         self._source_length = length
         self._source_type = "ellipticundulator"
 
+class UE44(Apple2):
+    """Ue44 Apple2 class.
+
+    Args:
+        Apple2 (Apple2 class): Apple2 class
+    
+    """
+    def __init__(self, period = 44, length = 3.4):
+        """Class constructor.
+
+        Args:
+            period (float, optional): Undulator period [mm].
+             period. Defalts to 44 mm.
+            length (float, optional): Undulator length [m].
+             length. Defalts to 3.4 m.
+        """
+        super().__init__(period, length)
+        self._br = 1.14
+
 
 class Delta(Undulator):
     """Delta Undulator class.


### PR DESCRIPTION
Foi adicionada uma nova classe UE44 em sources derivada da classe Apple2, com valor de periodo pré-definido para 44mm e comprimento de 3.4m e com o novo campo remanente para que tenha os valores de k:

3.5 (hp)​
2.5 (vp)​
1.9 (cp)

para o gap min físico de 11.4 mm