### PR TITLE
Epus

### DIFF
--- a/spectrainterface/sources.py
+++ b/spectrainterface/sources.py
@@ -472,7 +472,7 @@ class Apple2(Undulator):
         self._source_type = "ellipticundulator"
 
 class Ue44(Apple2):
-    """Ue44  class"""
+    """Ue44  class."""
     def __init__(self, period=44, length=3.4):
         """Class constructor."""
         super().__init__(period, length)
@@ -480,6 +480,25 @@ class Ue44(Apple2):
         self._gap = 11.4
         self._br = 1.14
 
+class Epu50(Apple2):
+    """Epu50 uvx class."""
+    def __init__(self, period=50, length=3):
+        """Class constructor."""
+        super().__init__(period, length)
+        self._label = 'Epu50'
+        self._br = 1.24
+        self._gap = 10.3
+        
+
+class Epu50_uvx(Apple2):
+    """Epu50 uvx class."""
+    def __init__(self, period=50, length=2.7):
+        """Class constructor."""
+        super().__init__(period, length)
+        self._label = 'Epu50 (UVX)'
+        self._br = 1.135
+        self._gap = 22
+        
 
 class Delta(Undulator):
     """Delta Undulator class.

--- a/spectrainterface/sources.py
+++ b/spectrainterface/sources.py
@@ -481,7 +481,7 @@ class Ue44(Apple2):
         self._br = 1.14
 
 class Epu50(Apple2):
-    """Epu50 uvx class."""
+    """Epu50 class."""
     def __init__(self, period=50, length=3):
         """Class constructor."""
         super().__init__(period, length)


### PR DESCRIPTION
Foi adicionada a classe do epu50 e do epu50_uvx com seus respectivos campo remanente, gap e periodo, para se aproximar dos k's de cada polarização que tá na tabela da nossa apresentação