### PR TITLE
added .png extension to avoid bug when label has a dot

### DIFF
--- a/spectrainterface/wikigen.py
+++ b/spectrainterface/wikigen.py
@@ -85,7 +85,7 @@ class FunctionsManipulation:
                 source.source_length,
                 source.period,
             )
-            figname = "flux_density_{:}_{:.0f}m_{:.0f}mm_{:.0f}keV".format(
+            figname = "flux_density_{:}_{:.0f}m_{:.0f}mm_{:.0f}keV.png".format(
                 source.label,
                 source.source_length,
                 source.period,
@@ -97,7 +97,7 @@ class FunctionsManipulation:
                 distance_from_source,
                 source.label,
             )
-            figname = "flux_density_{:}_{:.0f}keV".format(
+            figname = "flux_density_{:}_{:.0f}keV.png".format(
                 source.label, target_energy * 1e-3
             )
         fig = _plt.figure(figsize=(figsize[0], figsize[0]))


### PR DESCRIPTION
minor bug fix: 
- when `id_params.label` contains a ".", e.g "CPMU14.6", everything after the dot was being considered as the figure extension in the `calc_options.flux_distribution_2d` function, and then it crashed when trying to save the figure.