### PR TITLE
Degree polarization

### DIFF
--- a/spectrainterface/interface.py
+++ b/spectrainterface/interface.py
@@ -4278,7 +4278,6 @@ class SpectraInterface:
                 kmax = source.undulator_b_to_k(b=beff, period=source.period)
             else:
                 kmax = source.calc_max_k(spectra_calc.accelerator)
-            kmax = source.calc_max_k(spectra_calc.accelerator)
             fst_energy = source.get_harmonic_energy(
                 n=1,
                 gamma=spectra_calc.accelerator.gamma,
@@ -4326,8 +4325,10 @@ class SpectraInterface:
                 spectra_calc.calc.slit_shape = slit_shape
                 spectra_calc.calc.slit_acceptance = slit_acceptance
                 spectra_calc.calc.k_range = [kmin, kmax]
+                print('k range: ', spectra_calc.calc.k_range)
                 spectra_calc.calc.k_nr_pts = k_nr_pts
                 spectra_calc.calc.harmonic_range = harmonic_range
+                print('harmonic range: ', spectra_calc.calc.harmonic_range)
                 if source.polarization == 'hp':
                     spectra_calc.calc.source_type = (
                         spectra_calc.calc.SourceType.horizontal_undulator

--- a/spectrainterface/interface.py
+++ b/spectrainterface/interface.py
@@ -4326,10 +4326,8 @@ class SpectraInterface:
                 spectra_calc.calc.slit_shape = slit_shape
                 spectra_calc.calc.slit_acceptance = slit_acceptance
                 spectra_calc.calc.k_range = [kmin, kmax]
-                print('k range: ', spectra_calc.calc.k_range)
                 spectra_calc.calc.k_nr_pts = k_nr_pts
                 spectra_calc.calc.harmonic_range = harmonic_range
-                print('harmonic range: ', spectra_calc.calc.harmonic_range)
                 if source.polarization == 'hp':
                     spectra_calc.calc.source_type = (
                         spectra_calc.calc.SourceType.horizontal_undulator

--- a/spectrainterface/interface.py
+++ b/spectrainterface/interface.py
@@ -2254,6 +2254,7 @@ class SpectraInterface:
 
         return x_list_trunc, y_list_trunc
 
+    @staticmethod
     def export_data(data: dict, filename: str):
         """Export data function.
 

--- a/spectrainterface/interface.py
+++ b/spectrainterface/interface.py
@@ -1804,7 +1804,7 @@ class Calc(GeneralConfigs, SpectraTools):
                     self._pl = data[:, 3, :]
                     self._pc = data[:, 4, :]
                     self._pl45 = data[:, 5, :]
-                if self.source_type == self.SourceType.elliptic_undulator:
+                elif self.source_type == self.SourceType.elliptic_undulator:
                     self._kx = data[:, 1, :]
                     self._ky = data[:, 2, :]
                     self._flux = data[:, 3, :]

--- a/spectrainterface/interface.py
+++ b/spectrainterface/interface.py
@@ -4376,8 +4376,9 @@ class SpectraInterface:
         degree_pl = spectra_calc.calc._pl
         degree_pc = spectra_calc.calc._pc
         degree_pl45 = spectra_calc.calc._pl45
+        flux = spectra_calc.flux
         del spectra_calc
-        return energies, degree_pl, degree_pc, degree_pl45
+        return energies.T, degree_pl.T, degree_pc.T, degree_pl45.T, flux.T
 
     def calc_power_density(
         self,


### PR DESCRIPTION
Fix bypass bug in the _set_outputs function of the Calc class

Before:
```python
if (
    self.source_type != self.SourceType.elliptic_undulator
    and self.source_type != self.SourceType.figure8_undulator
    and self.source_type
    != self.SourceType.vertical_figure8_undulator
):
    # set outputs...
if self.source_type == self.SourceType.elliptic_undulator:
    # set outputs ...
else:
    # set outputs ...
``` 

After:
```python
if (
    self.source_type != self.SourceType.elliptic_undulator
    and self.source_type != self.SourceType.figure8_undulator
    and self.source_type
    != self.SourceType.vertical_figure8_undulator
):
    # set outputs ...
elif self.source_type == self.SourceType.elliptic_undulator:
    # set outputs ...
else:
    # set outputs ...
``` 

**elif** instead of **if** prevents the outputs from being reordered.

In addition, flux output was added to the calc_degree_polarization function.

